### PR TITLE
Add page_after_footer block

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -116,6 +116,10 @@ main {
   .post-footer {
     margin-top: 20px;
     border-top: 1px solid #e6e6e6;
+
+    & + div {
+        clear: both;
+    }
   }
 
   .post-tags {

--- a/templates/page.html
+++ b/templates/page.html
@@ -65,6 +65,12 @@
             {% endif %}
 
         {% endblock page_footer %}
+
+    </div>
+
+    <div>
+    {% block page_after_footer %}
+    {% endblock page_after_footer %}
     </div>
 </article>
 


### PR DESCRIPTION
The block is surrounded by a `div` element because it should have a
`clear: both` style property to avoid overlaping with navigation anchors.

This should fix #17 .