### PR TITLE
Fix ToC generation

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -3,13 +3,13 @@
 
 {% block content %}
 
-{% if page.toc %}
+{% if toc %}
 <div class="post-toc" id="post-toc">
     <h2 class="post-toc-title">Contents</h2>
     <div class="post-toc-content always-active">
         <nav id="TableOfContents">
             <ul>
-                {% for h1 in page.toc %}
+                {% for h1 in toc %}
                 <li>
                     <a href="{{h1.permalink | safe}}" class="toc-link">{{ h1.title }}</a>
                     {% if h1.children %}

--- a/theme.toml
+++ b/theme.toml
@@ -2,7 +2,7 @@ name = "even"
 description = "A robust, elegant dark theme"
 license = "MIT"
 homepage = "https://github.com/getzola/even"
-min_version = "0.5.0"
+min_version = "0.6.0"
 demo = "https://zola-even.netlify.com"
 
 [extra]


### PR DESCRIPTION
Zola v0.6.0 had a breaking change: `page.toc` is now available as `toc`,
cf. https://github.com/getzola/zola/blob/master/CHANGELOG.md#060-2019-03-25 .

Ref https://github.com/getzola/zola/issues/651