### PR TITLE
fix(js): increase robustness of toc calculation

### DIFF
--- a/static/even.js
+++ b/static/even.js
@@ -36,6 +36,10 @@ function initToc() {
   var $tocLinkLis = document.querySelectorAll('.post-toc-content li')
 
   var searchActiveTocIndex = function (array, target) {
+    if (!array.length) {
+      return -1
+    }
+
     target += 30
     for (let i = 0; i < array.length - 1; i++) {
       if (target > array[i].offsetTop && target <= array[i + 1].offsetTop) return i
@@ -55,7 +59,7 @@ function initToc() {
       el.classList.remove('has-active')
     })
 
-    if (activeTocIndex !== -1) {
+    if ($toclink.length && activeTocIndex !== -1) {
       $toclink[activeTocIndex].classList.add('active')
       let ancestor = $toclink[activeTocIndex].parentNode
       while (ancestor.tagName !== 'NAV') {


### PR DESCRIPTION
I noticed some errors in the JavaScript console regarding the table of contents. My knowledge of the template is bad, so this only is a quick fix.

As far as I can judge from the code I have seen, this implementation of "Even" lacks displaying the table of contents entirely. Are there plans to include these? If not, I might tackle that in the future.

I further noticed some design differences to the hugo theme, so other PRs might follow.