### PR TITLE
fix(scss): provide proper style for footnotes

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -78,6 +78,32 @@ main {
       }
     }
 
+    .footnote-definition {
+      padding-left: 40px;
+
+      &:first-of-type {
+        border-top: 2px dashed $main-colour;
+        margin-top: 1rem;
+        padding-top: 1rem;
+      }
+
+      sup {
+        &.footnote-definition-label {
+          font-size: 100%;
+          position: unset;
+          top: unset;
+
+          &::after {
+            content: '.';
+          }
+        }
+      }
+
+      p {
+        display: inline;
+      }
+    }
+
     &__title {
       margin: 0;
       font-size: 30px;


### PR DESCRIPTION
The style is based on hugo's Even, see [1]. A good reference of how
markdown for footnotes is rendered can be found at [2].

[1]: https://themes.gohugo.io//theme/hugo-theme-even/post/markdown-syntax/
[2]: https://github.com/raphlinus/pulldown-cmark/blob/master/specs/footnotes.txt