### PR TITLE
Localise the taxonomies

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -45,7 +45,7 @@
             {% if page.taxonomies.tags %}
                 <div class="post-tags">
                     {% for tag in page.taxonomies.tags %}
-                        <a href="{{ get_taxonomy_url(kind="tags", name=tag) }}">#{{ tag }}</a>
+                        <a href="{{ get_taxonomy_url(kind="tags", name=tag, lang=lang) }}">#{{ tag }}</a>
                     {% endfor %}
                 </div>
             {% endif %}
@@ -69,4 +69,3 @@
 </article>
 
 {% endblock content %}
-

--- a/templates/post_macros.html
+++ b/templates/post_macros.html
@@ -7,7 +7,7 @@
             <span class="post__time">{{ page.date | date(format="%F") }}</span>
             {% if page.category %}
                 <div class="post__category">
-                    <a href="{{ get_taxonomy_url(kind="category", name=page.category) }}">{{ page.category }}</a>
+                    <a href="{{ get_taxonomy_url(kind="category", name=page.category, lang=lang) }}">{{ page.category }}</a>
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
Use the new `lang` parameter in `get_taxonomy_url` for tags and categories.