### PR TITLE
Delete CSS code that breaks words when word wrapping inside hyperlinks

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -45,7 +45,6 @@ main {
 
     p > a {
       color: $main-colour;
-      word-break: break-all;
 
       &:hover {
         border-bottom: 1px solid $main-colour;


### PR DESCRIPTION
As per issue #36.