### PR TITLE
Fix ToC generation (again)

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -5,13 +5,13 @@
 
 {% block content %}
 
-{% if toc %}
+{% if page.toc %}
 <div class="post-toc" id="post-toc">
     <h2 class="post-toc-title">Contents</h2>
     <div class="post-toc-content always-active">
         <nav id="TableOfContents">
             <ul>
-                {% for h1 in toc %}
+                {% for h1 in page.toc %}
                 <li>
                     <a href="{{h1.permalink | safe}}" class="toc-link">{{ h1.title }}</a>
                     {% if h1.children %}


### PR DESCRIPTION
The `toc` variable is back at `page.toc` or `section.toc` in 0.10,
see https://github.com/getzola/zola/blob/master/CHANGELOG.md#0100-2020-02-17 .