### PR TITLE
increase the color contrast for the code font

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -49,6 +49,7 @@ pre, code {
   overflow: auto;
   font-family: $code-font-family;
   margin-bottom: 0;
+  color: #c9d2dc;
 }
 
 pre > code {


### PR DESCRIPTION
The `code font` color inherits dark blue #0047AB, which is much too dark for the blackish background #2b303b it is printed on.
This PR increases the contrast by changing the font color to #c9d2dc a light grey. The change only applies when the code
language is unspecified (when no syntax highlighting is enabled).
Please have a look at [this sample](https://blog.getreu.net/20191126-midnight-commander-as-console-eml-and-mbox-email-file-viewer/).