### PR TITLE
feat: allow table of contents to expand to content width

### DIFF
--- a/sass/_toc.scss
+++ b/sass/_toc.scss
@@ -3,7 +3,7 @@ $toc-max-sreen-width: 2 * 200px + $post-toc-margin-left !default;
 
 .post-toc {
   position: absolute;
-  width: 200px;
+  min-width: 200px;
   margin-left: $post-toc-margin-left;
   padding: 10px;
   border-radius: 5px;


### PR DESCRIPTION
## Greetings

Hi :wave:. I just [switched my personal site to Zola](http://www.cbzehner.com/getting-started-with-zola/) yesterday and I am really happy with the Even theme. Thanks for providing this!

## Suggestion

I noticed one area that can be improved in the Table of Contents (TOC). The way it's structured currently it limits the character length that can be used for section titles. Note the way text-wrapping across multiple lines here breaks the visual structure:

![toc_before](https://user-images.githubusercontent.com/3886290/78830108-48b67e80-799c-11ea-8054-8b89387a917f.png)

Would you be open to changing the `width` setting here to be `min-width` instead? This will allow the TOC to expand if the interior content exceeds `200px` in width. The following screenshot demonstrates what the previous example looks like after this change.

![toc_after](https://user-images.githubusercontent.com/3886290/78830236-77345980-799c-11ea-9afa-06c92a4444f4.png)

## Edge Case

This doesn't completely resolve the issue, for instance the pathological case of extremely long text

![long_text](https://user-images.githubusercontent.com/3886290/78830513-f164de00-799c-11ea-9c4a-f0e1e9527344.png)

plus a zoom level of 175%, regresses to the current behavior.

![long_text_175_zoom](https://user-images.githubusercontent.com/3886290/78830549-fe81cd00-799c-11ea-913d-f75eb1349de8.png)

However, once we hit 200% zoom, the TOC disappears completely.

![200_zoom](https://user-images.githubusercontent.com/3886290/78830655-2a9d4e00-799d-11ea-85ad-8f1cfb90069c.png)
