### PR TITLE
Fix "jumping" when going from home to categories

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -8,6 +8,7 @@ body {
   color: #34495e;
   background: #fefefe;
   border-top: 3px solid $main-colour;
+  overflow-y: scroll;
 }
 
 .container {


### PR DESCRIPTION
Apparently, the scrollbar messes with the `margin: 0 auto` calculation.