### PR TITLE
Fix for latest Zola

### DIFF
--- a/content/markdown_overview.md
+++ b/content/markdown_overview.md
@@ -64,7 +64,3 @@ fn main() {
 
 ![a cat](https://placekitten.com/200/300?image=4 "A cat photo taken by Energetic
 Spirit (CC BY-SA 2.0)")
-
-## An iframe
-
-{{ youtube(id="dQw4w9WgXcQ") }}

--- a/content/some-article.md
+++ b/content/some-article.md
@@ -61,7 +61,3 @@ fn main() {
 ## An image
 
 ![a cat](https://i.imgur.com/t6nPdY8.jpg "A cat")
-
-## An iframe
-
-{{ youtube(id="dQw4w9WgXcQ") }}


### PR DESCRIPTION
Zola no longer has shortcodes bundled, this allows the theme to be built/served by the latest version Zola.