### PR TITLE
sass 'use', lighthouse/observatory tweaks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@ base_url = "https://zola-even.netlify.app"
 
 compile_sass = true
 title = "even theme"
-description = ""
+description = "A clean, responsive theme"
 generate_feed = true
 
 taxonomies = [
@@ -13,6 +13,7 @@ taxonomies = [
 
 [markdown]
 highlight_code = true
+highlight_theme = "css"
 
 [extra]
 author = "Vincent"

--- a/content/markdown_overview.md
+++ b/content/markdown_overview.md
@@ -62,5 +62,4 @@ fn main() {
 
 ## An image
 
-![a cat](https://placekitten.com/200/300?image=4 "A cat photo taken by Energetic
-Spirit (CC BY-SA 2.0)")
+![a cat](https://i.imgur.com/dmnJACE.jpg "A cat")

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,17 @@
     command = "zola build"
 
 [build.environment]
-    ZOLA_VERSION = "0.16.0"
+    ZOLA_VERSION = "0.17.2"
 
 [context.deploy-preview]
     command = "zola build --base-url $DEPLOY_PRIME_URL"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    X-XSS-Protection = "1; mode=block"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Strict-Transport-Security = "max-age=63072000; includeSubdomains"
+    Content-Security-Policy = "default-src 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; manifest-src 'self'; connect-src 'self'; form-action 'self'; script-src 'self' cdnjs.cloudflare.com; img-src 'self' i.imgur.com data: cdn.cloudflare.com; frame-src 'self' www.youtube-nocookie.com player.vimeo.com; media-src 'self' data: cdn.cloudflare.com www.youtube-nocookie.com player.vimeo.com; font-src 'self' cdn.cloudflare.com cdn.jsdelivr.net fonts.gstatic.com; style-src 'self' cdn.cloudflare.com cdn.jsdelivr.net fonts.googleapis.com;"

--- a/sass/_animations.scss
+++ b/sass/_animations.scss
@@ -1,3 +1,4 @@
+@use "variables";
 @mixin underline-from-center() {
   display: inline-block;
   vertical-align: middle;
@@ -15,7 +16,7 @@
     bottom: 0;
     left: 51%;
     right: 51%;
-    background: $main-colour;
+    background: variables.$main-colour;
     transition-duration: 0.2s;
     transition-property: right, left;
     transition-timing-function: ease-out;
@@ -104,7 +105,7 @@
     top: calc((100% - 1px) / 2);
     width: 20px;
     height: 1px;
-    background-color: $main-colour;
+    background-color: variables.$main-colour;
 
     &:nth-child(1) {
       transform: translateY(6px) rotate(0deg);

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -1,3 +1,4 @@
+@use "variables";
 html {
   font-size: 16px;
   box-sizing: border-box;
@@ -7,17 +8,17 @@ body {
   line-height: 1.5;
   color: #34495e;
   background: #fefefe;
-  border-top: 3px solid $main-colour;
+  border-top: 3px solid variables.$main-colour;
   overflow-y: scroll;
 }
 
 .container {
-  width: $body-width;
+  width: variables.$body-width;
   margin: 0 auto;
   padding-bottom: 4rem;
 }
 
-@include max-screen() {
+@include variables.max-screen() {
   body {
     border-top: 0;
   }
@@ -29,7 +30,7 @@ body {
 }
 
 a {
-  color: $main-colour;
+  color: variables.$main-colour;
   text-decoration: none;
 }
 
@@ -48,7 +49,7 @@ pre {
 pre, code {
   font-size: 90%;
   overflow: auto;
-  font-family: $code-font-family;
+  font-family: variables.$code-font-family;
   margin-bottom: 0;
   color: #c9d2dc;
 }

--- a/sass/_header.scss
+++ b/sass/_header.scss
@@ -1,3 +1,5 @@
+@use "variables";
+@use "animations";
 #header {
   padding: 20px;
   display: flex;
@@ -15,7 +17,7 @@
 
   .menu {
     align-self: flex-start;
-    font-family: $decoration-font-family;
+    font-family: variables.$decoration-font-family;
 
     ul {
       display: inline-block;
@@ -24,7 +26,7 @@
       li {
         display: inline-block;
         margin-right: 5px;
-        @include underline-from-center;
+        @include animations.underline-from-center;
 
         a {
           color: #34495e;
@@ -34,7 +36,7 @@
     }
   }
 }
-@include max-screen() {
+@include variables.max-screen() {
   #header {
     .logo, .menu {
       display: none;

--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -1,3 +1,5 @@
+@use "variables";
+@use "animations";
 main {
   clear: both;
 
@@ -11,8 +13,8 @@ main {
   }
 
   .read-more a {
-    color: $main-colour;
-    font-family: $decoration-font-family;
+    color: variables.$main-colour;
+    font-family: variables.$decoration-font-family;
     font-size: 1.1rem;
 
     &:hover {
@@ -25,7 +27,7 @@ main {
     padding: 1.5rem 0;
 
     .post__title {
-      font-family: $decoration-font-family;
+      font-family: variables.$decoration-font-family;
 
       a {
         color: #34495e;
@@ -39,15 +41,15 @@ main {
     :not(pre) > code {
       padding: 3px 5px;
       border-radius: 4px;
-      color: $code-colour;
-      background: $secondary-colour;
+      color: variables.$code-colour;
+      background: variables.$secondary-colour;
     }
 
     p > a {
-      color: $main-colour;
+      color: variables.$main-colour;
 
       &:hover {
-        border-bottom: 1px solid $main-colour;
+        border-bottom: 1px solid variables.$main-colour;
       }
     }
 
@@ -73,16 +75,16 @@ main {
       box-shadow: 2px 2px 3px rgba(0, 0, 0, .125);
 
       thead {
-        background: $secondary-colour;
+        background: variables.$secondary-colour;
       }
 
       th, td {
         padding: 5px 15px;
-        border: 1px double darken($secondary-colour, 3%);
+        border: 1px double darken(variables.$secondary-colour, 3%);
       }
 
       tr:hover {
-        background-color: $secondary-colour;
+        background-color: variables.$secondary-colour;
       }
     }
 
@@ -90,7 +92,7 @@ main {
       padding-left: 40px;
 
       &:first-of-type {
-        border-top: 2px dashed $main-colour;
+        border-top: 2px dashed variables.$main-colour;
         margin-top: 1rem;
         padding-top: 1rem;
       }
@@ -117,7 +119,7 @@ main {
       font-size: 26px;
       font-weight: 400;
 
-      @include underline-from-center;
+      @include animations.underline-from-center;
     }
 
     &__category {
@@ -132,14 +134,14 @@ main {
         }
 
         &:hover {
-          color: $main-colour;
+          color: variables.$main-colour;
         }
       }
     }
 
     &__meta {
       font-size: 14px;
-      color: #8a8a8a;
+      color: #757575;
     }
 
     &__summary {
@@ -165,7 +167,7 @@ main {
 
     a {
       margin-right: 5px;
-      color: $main-colour;
+      color: variables.$main-colour;
       word-break: break-all;
     }
   }
@@ -180,7 +182,7 @@ main {
 
   .pagination {
     clear: both;
-    font-family: $decoration-font-family;
+    font-family: variables.$decoration-font-family;
     margin: 2rem 0;
 
     a {
@@ -195,7 +197,7 @@ main {
   transition: transform 0.3s ease-out;
 
   &:hover {
-    color: $main-colour;
+    color: variables.$main-colour;
   }
 }
 
@@ -220,8 +222,8 @@ main {
   &__title {
     display: inline-block;
     font-size: 18px;
-    color: $main-colour;
-    border-bottom: 2px solid $main-colour;
+    color: variables.$main-colour;
+    border-bottom: 2px solid variables.$main-colour;
   }
 
   &__items {
@@ -233,14 +235,14 @@ main {
       position: relative;
 
       &:hover {
-        color: $main-colour;
+        color: variables.$main-colour;
       }
 
       .count {
         position: relative;
         top: -8px;
         right: -2px;
-        color: $main-colour;
+        color: variables.$main-colour;
         font-size: 12px;
       }
     }
@@ -256,28 +258,28 @@ main {
     transition: 0.2s ease-out;
 
     &:hover {
-      border-left: 3px solid $main-colour;
+      border-left: 3px solid variables.$main-colour;
       transform: translateX(4px);
     }
 
     &__time {
       margin-right: 10px;
-      color: #8a8a8a;
+      color: #757575;
     }
 
     &__title a {
-      color: $main-colour;
+      color: variables.$main-colour;
     }
   }
 }
 
 .about {
   p > a {
-    color: $main-colour;
+    color: variables.$main-colour;
     word-break: break-all;
 
     &:hover {
-      border-bottom: 1px solid $main-colour;
+      border-bottom: 1px solid variables.$main-colour;
     }
   }
 }

--- a/sass/_mobile.scss
+++ b/sass/_mobile.scss
@@ -1,3 +1,5 @@
+@use "variables";
+@use "animations";
 // ==============================
 // Mobile Navbar
 // ==============================
@@ -8,7 +10,7 @@
   top: 0;
   left: 0;
   width: 100%;
-  height: $mobile-navbar-height;
+  height: variables.$mobile-navbar-height;
   background: white;
   box-shadow: 0px 2px 2px #cacaca;
   text-align: center;
@@ -25,51 +27,51 @@
 
     .logo {
       font-size: 22px;
-      line-height: $mobile-navbar-height;
+      line-height: variables.$mobile-navbar-height;
     }
   }
 
   .mobile-navbar-icon {
     cursor: pointer;
-    color: $main-colour;
-    height: $mobile-navbar-height;
-    width: $mobile-navbar-height;
+    color: variables.$main-colour;
+    height: variables.$mobile-navbar-height;
+    width: variables.$mobile-navbar-height;
     font-size: 24px;
     text-align: center;
     float: left;
     position: relative;
     transition: background 0.5s;
 
-    @include mobile-menu-icon();
+    @include animations.mobile-menu-icon();
   }
 }
 
 .mobile-menu {
-  background-color: rgba($secondary-colour, 0.5);
+  background-color: rgba(variables.$secondary-colour, 0.5);
 
   .mobile-menu-list {
     position: relative;
     list-style: none;
     margin-top: 50px;
     padding: 0;
-    border-top: 1px solid $secondary-colour;
+    border-top: 1px solid variables.$secondary-colour;
 
     .mobile-menu-item {
       padding: 10px 30px;
-      border-bottom: 1px solid $secondary-colour;
+      border-bottom: 1px solid variables.$secondary-colour;
     }
 
     a {
       font-size: 18px;
 
       &:hover {
-        color: $main-colour;
+        color: variables.$main-colour;
       }
     }
   }
 }
 
-@include max-screen() {
+@include variables.max-screen() {
   .mobile-navbar {
     display: block;
   }

--- a/sass/_syntax-charcoal.scss
+++ b/sass/_syntax-charcoal.scss
@@ -1,0 +1,162 @@
+@mixin dark {
+    .z-code {
+    color: #cccece;
+    background-color: #191919;
+    }
+    .z-comment, .z-punctuation.z-definition.z-comment {
+    color: #7e8384;
+    }
+    .z-variable {
+    color: #cccece;
+    }
+    .z-keyword, .z-storage.z-type, .z-storage.z-modifier {
+    color: #c594c5;
+    }
+    .z-keyword.z-operator, .z-constant.z-other.z-color, .z-punctuation, .z-meta.z-tag, .z-punctuation.z-definition.z-tag, .z-punctuation.z-separator.z-inheritance.z-php, .z-punctuation.z-definition.z-tag.z-html, .z-punctuation.z-definition.z-tag.z-begin.z-html, .z-punctuation.z-definition.z-tag.z-end.z-html, .z-punctuation.z-section.z-embedded, .z-keyword.z-other.z-template, .z-keyword.z-other.z-substitution {
+    color: #5fb3b3;
+    }
+    .z-entity.z-name.z-tag, .z-meta.z-tag.z-sgml, .z-markup.z-deleted.z-git_gutter {
+    color: #ff7b84;
+    }
+    .z-entity.z-name.z-function, .z-meta.z-function-call, .z-variable.z-function, .z-support.z-function, .z-keyword.z-other.z-special-method, .z-meta.z-block-level {
+    color: #78aade;
+    }
+    .z-support.z-other.z-variable, .z-string.z-other.z-link {
+    color: #fa7e81;
+    }
+    .z-constant.z-numeric, .z-constant.z-language, .z-support.z-constant, .z-constant.z-character, .z-variable.z-parameter, .z-keyword.z-other.z-unit {
+    color: #f99157;
+    }
+    .z-string, .z-constant.z-other.z-symbol, .z-constant.z-other.z-key, .z-entity.z-other.z-inherited-class, .z-markup.z-heading, .z-markup.z-inserted.z-git_gutter, .z-meta.z-group.z-braces.z-curly .z-constant.z-other.z-object.z-key.z-js .z-string.z-unquoted.z-label.z-js {
+    color: #99c794;
+    }
+    .z-entity.z-name.z-class, .z-entity.z-name.z-type.z-class, .z-support.z-type, .z-support.z-class, .z-support.z-orther.z-namespace.z-use.z-php, .z-meta.z-use.z-php, .z-support.z-other.z-namespace.z-php, .z-markup.z-changed.z-git_gutter {
+    color: #fac863;
+    }
+    .z-entity.z-name.z-module.z-js, .z-variable.z-import.z-parameter.z-js, .z-variable.z-other.z-class.z-js {
+    color: #fe7d83;
+    }
+    .z-variable.z-language {
+    color: #fe7d83;
+    }
+    .z-entity.z-name.z-method.z-js {
+    color: #d8dee9;
+    }
+    .z-meta.z-class-method.z-js .z-entity.z-name.z-function.z-js, .z-variable.z-function.z-constructor {
+    color: #d8dee9;
+    }
+    .z-entity.z-other.z-attribute-name {
+    color: #cd91c4;
+    }
+    .z-markup.z-inserted {
+    color: #99c794;
+    }
+    .z-markup.z-deleted {
+    color: #fe7d83;
+    }
+    .z-markup.z-changed {
+    color: #cd91c4;
+    }
+    .z-string.z-regexp {
+    color: #5fb3b3;
+    }
+    .z-constant.z-character.z-escape {
+    color: #5fb3b3;
+    }
+    .z-*url*, .z-*link*, .z-*uri* {
+    text-decoration: underline;
+    }
+    .z-constant.z-numeric.z-line-number.z-find-in-files {
+    color: #cf9a87;
+    }
+    .z-entity.z-name.z-filename.z-find-in-files {
+    color: #99c794;
+    }
+    .z-tag.z-decorator.z-js .z-entity.z-name.z-tag.z-js, .z-tag.z-decorator.z-js .z-punctuation.z-definition.z-tag.z-js {
+    color: #78aade;
+    }
+    .z-source.z-js .z-constant.z-other.z-object.z-key.z-js .z-string.z-unquoted.z-label.z-js {
+    color: #fe7d83;
+    }
+}
+@mixin light {
+    .z-code {
+    color: #727373;
+    background-color: #ffffff;
+    }
+    .z-comment, .z-punctuation.z-definition.z-comment {
+    color: #5f6364;
+    }
+    .z-variable {
+    color: #727373;
+    }
+    .z-keyword, .z-storage.z-type, .z-storage.z-modifier {
+    color: #916392;
+    }
+    .z-keyword.z-operator, .z-constant.z-other.z-color, .z-punctuation, .z-meta.z-tag, .z-punctuation.z-definition.z-tag, .z-punctuation.z-separator.z-inheritance.z-php, .z-punctuation.z-definition.z-tag.z-html, .z-punctuation.z-definition.z-tag.z-begin.z-html, .z-punctuation.z-definition.z-tag.z-end.z-html, .z-punctuation.z-section.z-embedded, .z-keyword.z-other.z-template, .z-keyword.z-other.z-substitution {
+    color: #237e7f;
+    }
+    .z-entity.z-name.z-tag, .z-meta.z-tag.z-sgml, .z-markup.z-deleted.z-git_gutter {
+    color: #ca4251;
+    }
+    .z-entity.z-name.z-function, .z-meta.z-function-call, .z-variable.z-function, .z-support.z-function, .z-keyword.z-other.z-special-method, .z-meta.z-block-level {
+    color: #4076a7;
+    }
+    .z-support.z-other.z-variable, .z-string.z-other.z-link {
+    color: #c14c52;
+    }
+    .z-constant.z-numeric, .z-constant.z-language, .z-support.z-constant, .z-constant.z-character, .z-variable.z-parameter, .z-keyword.z-other.z-unit {
+    color: #b75922;
+    }
+    .z-string, .z-constant.z-other.z-symbol, .z-constant.z-other.z-key, .z-entity.z-other.z-inherited-class, .z-markup.z-heading, .z-markup.z-inserted.z-git_gutter, .z-meta.z-group.z-braces.z-curly .z-constant.z-other.z-object.z-key.z-js .z-string.z-unquoted.z-label.z-js {
+    color: #517c4e;
+    }
+    .z-entity.z-name.z-class, .z-entity.z-name.z-type.z-class, .z-support.z-type, .z-support.z-class, .z-support.z-orther.z-namespace.z-use.z-php, .z-meta.z-use.z-php, .z-support.z-other.z-namespace.z-php, .z-markup.z-changed.z-git_gutter {
+    color: #926c00;
+    }
+    .z-entity.z-name.z-module.z-js, .z-variable.z-import.z-parameter.z-js, .z-variable.z-other.z-class.z-js {
+    color: #cb414d;
+    }
+    .z-variable.z-language {
+    color: #cb414d;
+    }
+    .z-entity.z-name.z-method.z-js {
+    color: #6c727c;
+    }
+    .z-meta.z-class-method.z-js .z-entity.z-name.z-function.z-js, .z-variable.z-function.z-constructor {
+    color: #6c727c;
+    }
+    .z-entity.z-other.z-attribute-name {
+    color: #996091;
+    }
+    .z-markup.z-inserted {
+    color: #517c4e;
+    }
+    .z-markup.z-deleted {
+    color: #cb414d;
+    }
+    .z-markup.z-changed {
+    color: #996091;
+    }
+    .z-string.z-regexp {
+    color: #237e7f;
+    }
+    .z-constant.z-character.z-escape {
+    color: #237e7f;
+    }
+    .z-*url*, .z-*link*, .z-*uri* {
+    text-decoration: underline;
+    }
+    .z-constant.z-numeric.z-line-number.z-find-in-files {
+    color: #976756;
+    }
+    .z-entity.z-name.z-filename.z-find-in-files {
+    color: #517c4e;
+    }
+    .z-tag.z-decorator.z-js .z-entity.z-name.z-tag.z-js, .z-tag.z-decorator.z-js .z-punctuation.z-definition.z-tag.z-js {
+    color: #4076a7;
+    }
+    .z-source.z-js .z-constant.z-other.z-object.z-key.z-js .z-string.z-unquoted.z-label.z-js {
+    color: #cb414d;
+    }
+}

--- a/sass/_toc.scss
+++ b/sass/_toc.scss
@@ -1,4 +1,5 @@
-$post-toc-margin-left: $body-width - 15px !default;
+@use "variables";
+$post-toc-margin-left: variables.$body-width - 15px !default;
 $toc-max-sreen-width: 2 * 200px + $post-toc-margin-left !default;
 
 .post-toc {
@@ -47,11 +48,11 @@ $toc-max-sreen-width: 2 * 200px + $post-toc-margin-left !default;
     }
 
     .toc-link.active {
-      color: $main-colour;
+      color: variables.$main-colour;
     }
   }
 }
-@include max-screen($toc-max-sreen-width) {
+@include variables.max-screen($toc-max-sreen-width) {
   .post-toc {
     display: none;
   }

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,0 +1,28 @@
+$theme-color-map: (
+  'Default': #bb5649 #f8f5ec,
+  'Mint Green': #16982B #f5f5f5,
+  'Cobalt Blue': #0047AB #f0f2f5,
+  'Hot Pink': #FF69B4 #f8f5f5,
+  'Dark Violet': #9932CC #f5f4fa
+);
+
+// TODO: allow to change that
+$main-colour: #bb5649;
+$secondary-colour: #f8f5ec;
+$body-width: 800px;
+$mobile-navbar-height: 50px !default;
+$code-colour: #c7254e;
+$code-font-family: Consolas, Monaco, Menlo, Consolas, monospace !default;
+$decoration-font-family: Athelas, STHeiti, Microsoft Yahei, serif;
+
+@mixin min-screen($min-width: $body-width) {
+   @media screen and (min-width: $min-width) {
+     @content;
+   }
+}
+
+@mixin max-screen($max-width: $body-width) {
+   @media screen and (max-width: $max-width) {
+     @content;
+   }
+}

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -1,39 +1,15 @@
-@import "normalize";
+@use "normalize";
 
-$theme-color-map: (
-  'Default': #c05b4d #f8f5ec,
-  'Mint Green': #16982B #f5f5f5,
-  'Cobalt Blue': #0047AB #f0f2f5,
-  'Hot Pink': #FF69B4 #f8f5f5,
-  'Dark Violet': #9932CC #f5f4fa
-);
+@use "variables";
 
-// TODO: allow to change that
-$main-colour: #c05b4d;
-$secondary-colour: #f8f5ec;
-$body-width: 800px;
-$mobile-navbar-height: 50px !default;
-$code-colour: #c7254e;
-$code-font-family: Consolas, Monaco, Menlo, Consolas, monospace !default;
-$decoration-font-family: Athelas, STHeiti, Microsoft Yahei, serif;
+@use "animations";
 
-@mixin min-screen($min-width: $body-width) {
-   @media screen and (min-width: $min-width) {
-     @content;
-   }
-}
+@use "base";
+@use "header";
+@use "main";
+@use "mobile";
+@use "slideout";
+@use "toc";
 
-@mixin max-screen($max-width: $body-width) {
-   @media screen and (max-width: $max-width) {
-     @content;
-   }
-}
-
-@import "animations";
-
-@import "base";
-@import "header";
-@import "main";
-@import "mobile";
-@import "slideout";
-@import "toc";
+@use "syntax-charcoal" as syntax;
+@include syntax.light;

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,17 @@
       <meta http-equiv="content-type" content="text/html; charset=utf-8">
 
       <!-- Enable responsiveness on mobile devices-->
-      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    {% if page %}
+      {% if page.description %}
+      <meta name="description" content="{{ page.description }}" />
+      {% elif config.description %}
+      <meta name="description" content="{{ config.description }}" />
+      {% endif %}
+    {% elif config.description %}
+      <meta name="description" content="{{ config.description }}" />
+    {% endif %}
 
       <title>{% block title %}{{ config.title }}{% endblock title %}</title>
 

--- a/theme.toml
+++ b/theme.toml
@@ -2,7 +2,7 @@ name = "even"
 description = "A robust, elegant dark theme"
 license = "MIT"
 homepage = "https://github.com/getzola/even"
-min_version = "0.16.0"
+min_version = "0.17.0"
 demo = "https://zola-even.netlify.app"
 
 [extra]


### PR DESCRIPTION
- Updated sass to `@use` instead of `@import` [import deprecated](https://github.com/sass/sass/blob/main/accepted/module-system.md#timeline)
- Update theme.toml min_version to 0.17.0 (to support `@use`)
- Tweaks for Lighthouse/Observatory Scores.